### PR TITLE
stop using deprecated Class::MOP::load_class

### DIFF
--- a/lib/Elastic/Model/TypeMap/Base.pm
+++ b/lib/Elastic/Model/TypeMap/Base.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Sub::Exporter qw(build_exporter);
+use Class::Load qw(load_class);
 use Class::MOP();
 use List::MoreUtils qw(uniq);
 use Moose::Util qw(does_role);
@@ -40,7 +41,7 @@ sub import {
 
     for (@args) {
         next if /^[:-]/;
-        Class::MOP::load_class($_);
+        load_class($_);
         $callee->import_types( $_->typemap );
     }
 }


### PR DESCRIPTION
Hello,

Elastic::Model emits deprecation warnings when used with the latest Moose (2.1200), because of it's use of Class::MOP::load_class.  This patch replaces Class::MOP::load_class with Class::Load::load_class. See RT#91002  (https://rt.cpan.org/Public/Bug/Display.html?id=91002).  Please let me know if you'd like me to make any changes and have a great day!

Cheers,
Fitz
